### PR TITLE
relax version bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRED = [
     "networkx",
     "numpy",
     "PySMT>=0.9.6.dev53",
-    "sympy==1.9", # required for pyxadd engine
+    "sympy>=1.9", # required for pyxadd engine
     # test
     "pytest",
     "pytest-runner",


### PR DESCRIPTION
I found the version bound to be overly restrictive for pyxadd, it works with the current sympy version. Pinning it at this version leads to lots of conflicts with other packages that rely on sympy as it is quite old